### PR TITLE
#23: fix:Disable start game button until at least two players are added

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -262,7 +262,7 @@ class App extends Component {
                     <h3>Add Players</h3>
                     <PlayerForm onSubmit={this.addPlayer}/>
 
-                    { this.state.players.length > 0
+                    { this.state.players.length > 1
                         ? <Button onClick={this.startGame} block outline context="primary" title="Start Game"/>
                         : null }
                 </div>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -54,19 +54,21 @@ test('ballHasBeenPorted', () => {
 describe ('add player', () => {
     const name = "Topher";
     let app;
+    let appWrapper;
     beforeEach (() => {
-        app = mount(<App/>);
+        appWrapper = mount(<App/>);
+        app = appWrapper.node;
     });
     it ('as function', () => {
-        app.node.addPlayer(name);
-        expect(app.node.state.players[0]).toEqual( { name: name, points: 0, active: true });
+        app.addPlayer(name);
+        expect(app.state.players[0]).toEqual( { name: name, points: 0, active: true });
     });
     it ('as event', () => {
-        const input = app.find('#player_name');
+        const input = appWrapper.find('#player_name');
         input.node.value = name;
         input.simulate('change');
-        app.find('form').simulate('submit');
-        expect(app.node.state.players[0]).toEqual( { name: name, points: 0, active: true });
+        appWrapper.find('form').simulate('submit');
+        expect(app.state.players[0]).toEqual( { name: name, points: 0, active: true });
     });
 });
 
@@ -82,15 +84,23 @@ describe ('start game', () => {
         app.startGame();
         expect(app.state.gameStarted).toBeTruthy();
     });
+
+    it ('button should not be visible unless at least two players are added', () => {
+        appWrapper.update();
+        expect(appWrapper.find('button.btn-outline-primary').exists()).toBeFalsy();
+    });
+
     it ('as event', () => {
+        app.state.players.push({ name: "Player 2", points: 0, active: true });
         appWrapper.update();
         appWrapper.find('button.btn-outline-primary').simulate('click');
         expect(app.state.gameStarted).toBeTruthy();
     });
-
     it ('ballHasBeenPorted should be false', () => {
+        app.startGame();
         expect(app.ballHasBeenPorted(app.state.balls)).toBeFalsy();
     });
+
 });
 
 
@@ -212,8 +222,6 @@ describe ('Player One hits the wrong ball when one has been ported', () => {
     app.state.currentPlayer = 0;
     app.state.balls[6].active = false;
     appWrapper.update();
-
-    const originalBall = app.state.currentBall;
 
     appWrapper.find('button.btn-block.btn-danger').last().simulate('click');
     appWrapper.find('button.btn-ball').at(1).simulate('click');


### PR DESCRIPTION
## What does this PR do? ##

Hides the start game button until at least two players are added

## Description of Task to be completed? ##

Check that the length of the player array > 2 before showing the button
Update the start game tests to test for the disabled button

## How should this be manually tested? ##

https://kanyuga.github.io/killer-counter
