### PR TITLE
Fixed #21: added confirm to resetGame and tests for resetGame

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -250,7 +250,9 @@ class App extends Component {
     };
 
     resetGame = () => {
-        this.setState(this.defaultGameState());
+        if (this.gameOver() || window.confirm('Start New Game? This cannot be undone')) {
+            this.setState(this.defaultGameState());
+        }
     };
 
     render() {


### PR DESCRIPTION
## What does this PR do?

Adds a confirmation dialog when the start game button is pressed if the current game is not yet over

## Description of Task to be completed?

Added a confirmation dialog to the resetGame method
Added tests for resetGame

## How should this be manually tested?

https://kanyuga.github.io/killer-counter