### PR TITLE
Fixed #16: Add option for porting current ball and then white ball

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -145,15 +145,22 @@ class App extends Component {
             foulHit: 'foul hit',
             port: 'ported',
             miss: 'missed',
+            portCurrentBallAndWhiteBall: `ported ${this.state.currentBall} and then ported the white ball`
         };
         let players = this.state.players.slice();
         let currentPlayer = this.state.players[this.state.currentPlayer];
         const balls = Object.assign({}, this.state.balls);
 
+        let logEntry = `${currentPlayer.name} ${typeLog[type]} ${number || this.state.currentBall}`;
+
+        if (type === 'portCurrentBallAndWhiteBall') {
+            logEntry = `${currentPlayer.name} ${typeLog[type]}`;
+        }
+
         const state = {
             currentPlayer: this.getNextPlayer(this.state.players),
             ballGridActive: false,
-            playLog: this.addLogEntry(`${currentPlayer.name} ${typeLog[type]} ${number || this.state.currentBall}`, type),
+            playLog: this.addLogEntry(logEntry, type),
         };
         
         switch(type) {
@@ -204,6 +211,14 @@ class App extends Component {
                 });
                 break;
 
+            case 'portCurrentBallAndWhiteBall':
+                const currentBall = balls[this.state.currentBall];
+                currentBall.active = false;
+                Object.assign(state, {
+                    currentPlayer: this.getNextPlayer(players),
+                    currentBall: this.getNextBall(balls)
+                });
+                break;
             default:
                 break;
         }
@@ -285,6 +300,7 @@ class App extends Component {
                             <BallGrid balls={this.state.balls} legal={false} onClick={(number) => this.play('foulHit', number)}/> :
                             null
                         }
+                        <Button onClick={() => this.play('portCurrentBallAndWhiteBall')} size="lg" block context="danger" title={`Port #${this.state.currentBall} and white ball`} />
                     </div>
                 );
             }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -281,7 +281,7 @@ describe ("Player One hits the wrong ball on the first move", () => {
     app.addPlayer("Player Two");
     app.startGame();
     appWrapper.update();
-    appWrapper.find('button.btn-block.btn-danger').last().simulate('click');
+    appWrapper.find('button.btn-block.btn-danger').at(1).simulate('click');
     appWrapper.find('button.btn-ball').at(1).simulate('click');
     const originalBall = app.state.currentBall;
 
@@ -308,10 +308,38 @@ describe ('Player One hits the wrong ball when one has been ported', () => {
     app.state.balls[6].active = false;
     appWrapper.update();
 
-    appWrapper.find('button.btn-block.btn-danger').last().simulate('click');
+    appWrapper.find('button.btn-block.btn-danger').at(1).simulate('click');
     appWrapper.find('button.btn-ball').at(1).simulate('click');
 
     it ("player one should have < 0 points since one has been ported already", () => {
         expect(app.state.players[0].points).toEqual(-4);
+    });
+});
+
+describe('Player ports the current ball and then ports the white ball', () => {
+    let appWrapper;
+    let app;
+    beforeEach (() =>{
+        appWrapper = mount(<App />);
+        app = appWrapper.node;
+        app.addPlayer("Player One");
+        app.addPlayer("Player Two");
+        app.startGame();
+    });
+    it ('as function', () => {
+        app.play('portCurrentBallAndWhiteBall');
+        const state = app.state;
+        expect(state.currentPlayer).toEqual(1);
+        expect(state.balls[3].active).toEqual(false);
+        expect(state.players[0].points).toEqual(0);
+        expect(state.currentBall).toEqual(4);
+    });
+    it ('as event', () => {
+        appWrapper.find('button.btn-danger').at(2).simulate('click');
+        const state = app.state;
+        expect(state.currentPlayer).toEqual(1);
+        expect(state.balls[3].active).toEqual(false);
+        expect(state.players[0].points).toEqual(0);
+        expect(state.currentBall).toEqual(4);
     });
 });


### PR DESCRIPTION
## What does this PR do?
Adds an play option for porting the current ball and then the white ball

## Description of task to be completed
Update play method to add new type
Add new button after Foul Port
Add tests