### PR TITLE
Fixed #35: prevent removal of last player if game is started

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -98,18 +98,23 @@ class App extends Component {
         };
 
         if (this.state.gameStarted) {
-            if (window.confirm(`Remove ${name}?`)) {
-                if (this.state.currentPlayer > index) {
-                    newState.currentPlayer = this.state.currentPlayer - 1
+            if (this.state.players.length > 1) {
+                if (window.confirm(`Remove ${name}?`)) {
+                    if (this.state.currentPlayer > index) {
+                        newState.currentPlayer = this.state.currentPlayer - 1
+                    }
+
+                    if (this.state.currentPlayer === index && players.length > 0) {
+                        newState.currentPlayer = this.getNextPlayer(players, this.state.currentPlayer - 1);
+                    }
+
+                    newState.playLog = this.addLogEntry(`${name} removed`);
+
+                    this.setGameState(newState);
                 }
-
-                if (this.state.currentPlayer === index && players.length > 0) {
-                    newState.currentPlayer = this.getNextPlayer(players, this.state.currentPlayer - 1);
-                }
-
-                newState.playLog = this.addLogEntry(`${name} removed`);
-
-                this.setGameState(newState);
+            }
+            else {
+                window.alert('The last player cannot be removed. Use the start game button.');
             }
         }
         else {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -117,6 +117,16 @@ describe('delete player', () => {
         expect(app.state.currentPlayer).toEqual(1);
     });
 
+    it ('when only one player is left ', () => {
+        app.state.players = app.state.players.slice(0, 1);
+        app.startGame();
+        const alertStub = sinon.stub(window, 'alert');
+        alertStub.returns(null);
+        app.deletePlayer(0);
+        expect(app.state.players.length).toEqual(1);
+        alertStub.restore();
+    });
+
     it ('as event', () => {
         appWrapper.update();
         appWrapper.find('.btn.btn-danger').at(2).simulate('click');


### PR DESCRIPTION
## What does this PR do?
Adds a check to the removePlayer method if there is only one player left.

## Description of task to be completed
Add condition to removePlayer and alert if there is only one player left and the game is active.

