### PR TITLE
[chore: #26] add circleci and codeclimate integration (#1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2
+jobs:
+  build:
+    environment:
+      CODECLIMATE_REPO_TOKEN: 1d92386039c561396d412a18d8d171f5b3441cada3c23e513e414836eab92701
+    docker:
+      - image: circleci/node:7.10
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+        
+      # run tests!
+      - run: sudo npm install -g codeclimate-test-reporter
+      - run: yarn test -- --coverage
+      - run: codeclimate-test-reporter < coverage/lcov.info
+
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Killer Counter
+
+[![CircleCI](https://circleci.com/gh/ProfNandaa/killer-counter/tree/master.svg?style=shield)](https://circleci.com/gh/ProfNandaa/killer-counter/tree/master) [![Test Coverage](https://codeclimate.com/github/ProfNandaa/killer-counter/badges/coverage.svg)](https://codeclimate.com/github/ProfNandaa/killer-counter/coverage) [![Code Climate](https://codeclimate.com/github/ProfNandaa/killer-counter/badges/gpa.svg)](https://codeclimate.com/github/ProfNandaa/killer-counter) [![Issue Count](https://codeclimate.com/github/ProfNandaa/killer-counter/badges/issue_count.svg)](https://codeclimate.com/github/ProfNandaa/killer-counter)
+
 This is an attempt to create a log for killer.
 
 ### How to Setup and Contribute


### PR DESCRIPTION
### What does this PR do?
This PR adds the integrations for CodeClimate (for quality and test coverage checks) and CircleCI for running the tests.

I've done this for my fork, but what needs to be done now is to add the integrations for the main repo, thus:
- Add project on CodeClimate - https://codeclimate.com/github/repos/new
- Add the project on CircleCI - https://circleci.com/add-projects/gh/kanyuga
- Update the badges on `README.md` from `profnandaa` to `kanyuga` username.
- Update CC repo token on line 5 of `.circleci/config.yml` with the new token obtained at `Settings > Test Coverage` tab on CodeClimate / or better still, remove that line and set it up from the CircleCI dashboard for better security.

closes #26 

### Side Note
When I was writing this issue initially, didn't know that we actually had [a good test coverage already](https://codeclimate.com/github/ProfNandaa/killer-counter/coverage). I'll therefore just look into the few remaining files, some of which like `src/registerServiceWorker.js` can be ignored.

### Screenshots
<img width="624" alt="screen shot 2017-08-12 at 3 18 16 pm" src="https://user-images.githubusercontent.com/261265/29240625-850bc4f8-7f71-11e7-9bab-0bb8b560217b.png">
